### PR TITLE
v1.10.0 Stream Control Integration and OBS/SA Hook Updates

### DIFF
--- a/meleeuploader/form.py
+++ b/meleeuploader/form.py
@@ -613,16 +613,15 @@ class MeleeUploader(BaseWidget):
         data = None
         ndata = None
         while True:
-            print("Checking streamcontrol.json")
             with open(self._scf.value) as f:
                 ndata = json.load(f)
                 if not data:
                     data = ndata
             if data['timestamp'] != ndata['timestamp']:
                 data = ndata
-                print("New timestamp")
                 mtype = ""
                 suffix = ""
+                prefix = ""
                 if consts.melee:
                     try:
                         self.__p1chars = self._p1char.value
@@ -653,10 +652,14 @@ class MeleeUploader(BaseWidget):
                             suffix = ""
                             sections = data['event_round'].split(t)
                             suffix = sections[1].strip()
+                            prefix = data['event_bracket']
+                        elif t.lower() in data['event_bracket'].lower():
+                            mtype = t
+                            prefix = ""
+                            suffix = ""
                     self._mtype.value = mtype
-                    self._mprefix.value = data['event_bracket']
+                    self._mprefix.value = prefix
                     self._msuffix.value = suffix
                 except Exception as e:
                     print(e)
-            print("Sleeping for 5 seconds")
             sleep(5)

--- a/meleeuploader/main.py
+++ b/meleeuploader/main.py
@@ -23,6 +23,7 @@ def main():
         consts.sheets = yt.get_spreadsheet_service()
         pyforms_lite.start_app(form.MeleeUploader, geometry=(200, 200, 1, 1))
     except Exception as e:
+        print(e)
         print("This program needs internet access to work")
         sys.exit(1)
 

--- a/meleeuploader/main.py
+++ b/meleeuploader/main.py
@@ -4,7 +4,7 @@ import os
 import sys
 import subprocess
 
-from . import form
+from . import forms
 from . import consts
 from . import youtube as yt
 
@@ -21,7 +21,7 @@ def main():
     try:
         consts.youtube = yt.get_youtube_service()
         consts.sheets = yt.get_spreadsheet_service()
-        pyforms_lite.start_app(form.MeleeUploader, geometry=(200, 200, 1, 1))
+        pyforms_lite.start_app(forms.MeleeUploader, geometry=(200, 200, 1, 1))
     except Exception as e:
         print(e)
         print("This program needs internet access to work")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from codecs import open
 from os import path
 
 here = path.abspath(path.dirname(__file__))
-version = '1.9.10'
+version = '1.10.0'
 
 long_des = ""
 with open(path.join(here, 'README.md')) as f:


### PR DESCRIPTION
# Updates
- Stream Control can now be hooked into by toggling the hook in settings
  - Small limitations exist because this was designed around Recursion's Stream Control, they include: 
    - JSON output required, file can be anywhere
    - player names must be outputted to keys `p1_name` and `p2 name`
    - character names must match how they are in the uploader and have keys `p1_char` and `p2_char`
    - Round info must be split into two parts `event_round` and `event_bracket`. `event_round` should be things like `Winners R1` or `Winners Finals`. `event_bracket` should be things like `Pools` or `Top 24`
  - Scoreboard Assistant and OBS hooks are no longer dependent on localhost